### PR TITLE
README: Add AUR installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Option 3. Build from source
 make build
 ```
 
+Option 4. AUR (build from source)
+
+```
+pikaur -S easy-conflict
+```
+
+Option 5. AUR (binary)
+
+```
+pikaur -S easy-conflict-bin
+```
+
 ## Quick start
 
 1. Run with no args inside a git repo that has conflicts


### PR DESCRIPTION
The current installation instructions only cover manual binary downloads, Homebrew, and building from source. This requires Arch Linux users to either manually download binaries or clone the repository, despite the tool being available in the Arch User Repository.

Document the two AUR installation methods (build from source and binary packages) to provide Arch users with the standard pacman-based workflow. This aligns with community expectations on Arch-based distributions where AUR is the primary distribution channel for third-party tools.