### PR TITLE
Remove tap instructions, move to Homebrew Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ec (easy-conflict) is a 3-way terminal native Git merge conflict resolver. Suppo
 ### Homebrew
 
 ```
-brew install chojs23/tap/ec
+brew install ec
 ```
 
 ### Npm


### PR DESCRIPTION
EC is now [available](https://github.com/Homebrew/homebrew-core/commit/0c60a7a1e60f4f0b8b4a153b9df75045d45120f6) to install directly via [Homebrew](https://brew.sh/).